### PR TITLE
Fix list markup on pages

### DIFF
--- a/app/mochi-diffusion/page.tsx
+++ b/app/mochi-diffusion/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
               Release page on Github.
             </Link>
           </li>
-          <>Set it up by clicking the dmg file.</>
+          <li>Set it up by clicking the dmg file.</li>
           <li>
             Prepare models. You can find them at{" "}
             <Link href={"https://huggingface.co/coreml"}>huggingface</Link> or

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,11 +5,13 @@ export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
       <div className="z-10 w-full max-w-5xl items-center justify-between font-mono lg:flex">
-        <li>
-          <Link href="/mochi-diffusion">
-            How to install Mochi Diffusion on Apple Silicon Mac
-          </Link>
-        </li>
+        <ul className="list-disc pl-5">
+          <li>
+            <Link href="/mochi-diffusion">
+              How to install Mochi Diffusion on Apple Silicon Mac
+            </Link>
+          </li>
+        </ul>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- fix HTML list markup on home page
- add missing list item on Mochi Diffusion instructions

## Testing
- `yarn lint` *(fails: package isn't in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68732415a64c832f948f2c98c432cc24